### PR TITLE
Template GitHub release version on maxiconda script

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      
+
     - name: Windows-only setup
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -87,9 +87,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip' # caching pip dependencies
+
+    - name: Install Jinja2
+      run: |
+        pip install Jinja2
+
     - name: Add maxiconda proxy for Linux/MacOS
       run: |
         mkdir build
+        export RELEASE_VERSION=${GITHUB_REF##*/}
+        python scripts/tag_script.py
         cp maxiconda.sh build/
 
     - name: Upload release assets

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,8 +49,8 @@ jobs:
         miniconda-version: "latest"
       if: contains(matrix.OS_NAME, 'Windows')
 
-    - name: Debugging with tmate
-      uses: mxschmitt/action-tmate@v3.13
+    # - name: Debugging with tmate
+    #   uses: mxschmitt/action-tmate@v3.13
 
     - name: Build and test maxiconda
       env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,9 @@ jobs:
         miniconda-version: "latest"
       if: contains(matrix.OS_NAME, 'Windows')
 
+    - name: Debugging with tmate
+      uses: mxschmitt/action-tmate@v3.13
+
     - name: Build and test maxiconda
       env:
         ARCH: ${{ matrix.ARCH }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+maxiconda.sh

--- a/maxiconda.sh.in
+++ b/maxiconda.sh.in
@@ -3,8 +3,8 @@
 USAGE_TXT="
 usage: $0
 
-This is a front-end for Linux- and MacOS- maxiconda installers. 
-It fetches the appropriate and most recent maxiconda installer for the 
+This is a front-end for Linux- and MacOS- maxiconda installers.
+It fetches the appropriate and most recent maxiconda installer for the
 current OS/CPU, checks the SHA256 signature and then runs it.
 
 "
@@ -41,11 +41,7 @@ case $CPU in
 esac
 
 ## URI's & COMMANDS ###
-BASE_URL="https://github.com/Semi-ATE/maxiconda/releases/latest/download/"
-VERSION_URL="https://api.github.com/repos/Semi-ATE/maxiconda/releases/latest"
-
-VERSION=`curl --silent $VERSION_URL | grep -Po '"tag_name": "\K.*?(?=")'`
-
+VERSION="{{ version }}"
 #[[ `curl --silent $VERSION_URL` =~ [^0-9]+([^\"]+)\" ]]
 #VERSION=${BASH_REMATCH[1]}
 INSTALLER="maxiconda-$VERSION-$OS_NAME-$CPU_NAME.sh"

--- a/maxiconda.sh.in
+++ b/maxiconda.sh.in
@@ -41,6 +41,7 @@ case $CPU in
 esac
 
 ## URI's & COMMANDS ###
+BASE_URL="https://github.com/Semi-ATE/maxiconda/releases/latest/download/"
 VERSION="{{ version }}"
 #[[ `curl --silent $VERSION_URL` =~ [^0-9]+([^\"]+)\" ]]
 #VERSION=${BASH_REMATCH[1]}

--- a/scripts/tag_script.py
+++ b/scripts/tag_script.py
@@ -1,0 +1,13 @@
+import os
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+version = os.environ.get('RELEASE_VERSION', '0.0.0')
+env = Environment(
+    loader=FileSystemLoader('.'),
+    autoescape=select_autoescape()
+)
+template = env.get_template("maxiconda.sh.in")
+out = template.render(version=version)
+
+with open('maxiconda.sh', 'w') as f:
+    f.write(out)


### PR DESCRIPTION
This PR embeds the release version into the `maxiconda.sh` script, thus preventing a call to the GitHub API