### PR TITLE
Remove pip cache from setup-python action

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -90,7 +90,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-        cache: 'pip' # caching pip dependencies
 
     - name: Install Jinja2
       run: |


### PR DESCRIPTION
This should prevent the `requirements.txt` missing failure